### PR TITLE
harden DataTables ORDER BY against SQL injection (part 1: sort direction)

### DIFF
--- a/application/models/DbTable/CertificateBatches.php
+++ b/application/models/DbTable/CertificateBatches.php
@@ -168,7 +168,9 @@ class Application_Model_DbTable_CertificateBatches extends Zend_Db_Table_Abstrac
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -2);

--- a/application/models/DbTable/CertificateBatches.php
+++ b/application/models/DbTable/CertificateBatches.php
@@ -168,7 +168,11 @@ class Application_Model_DbTable_CertificateBatches extends Zend_Db_Table_Abstrac
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -2);

--- a/application/models/DbTable/ContactUs.php
+++ b/application/models/DbTable/ContactUs.php
@@ -38,8 +38,10 @@ class Application_Model_DbTable_ContactUs extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/ContactUs.php
+++ b/application/models/DbTable/ContactUs.php
@@ -38,8 +38,12 @@ class Application_Model_DbTable_ContactUs extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/DataManagers.php
+++ b/application/models/DbTable/DataManagers.php
@@ -101,8 +101,10 @@ class Application_Model_DbTable_DataManagers extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/DataManagers.php
+++ b/application/models/DbTable/DataManagers.php
@@ -111,8 +111,12 @@ class Application_Model_DbTable_DataManagers extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Distribution.php
+++ b/application/models/DbTable/Distribution.php
@@ -29,8 +29,10 @@ class Application_Model_DbTable_Distribution extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -272,8 +274,10 @@ class Application_Model_DbTable_Distribution extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Distribution.php
+++ b/application/models/DbTable/Distribution.php
@@ -29,8 +29,12 @@ class Application_Model_DbTable_Distribution extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -413,8 +417,12 @@ class Application_Model_DbTable_Distribution extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/EidDetectionAssay.php
+++ b/application/models/DbTable/EidDetectionAssay.php
@@ -36,8 +36,10 @@ class Application_Model_DbTable_EidDetectionAssay extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/EidDetectionAssay.php
+++ b/application/models/DbTable/EidDetectionAssay.php
@@ -36,8 +36,12 @@ class Application_Model_DbTable_EidDetectionAssay extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/EidExtractionAssay.php
+++ b/application/models/DbTable/EidExtractionAssay.php
@@ -36,8 +36,10 @@ class Application_Model_DbTable_EidExtractionAssay extends Zend_Db_Table_Abstrac
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/EidExtractionAssay.php
+++ b/application/models/DbTable/EidExtractionAssay.php
@@ -36,8 +36,12 @@ class Application_Model_DbTable_EidExtractionAssay extends Zend_Db_Table_Abstrac
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Enrollments.php
+++ b/application/models/DbTable/Enrollments.php
@@ -28,8 +28,10 @@ class Application_Model_DbTable_Enrollments extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aSortColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aSortColumns[$colIdx])) { continue; }
+                    $sOrder .= $aSortColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Enrollments.php
+++ b/application/models/DbTable/Enrollments.php
@@ -28,8 +28,12 @@ class Application_Model_DbTable_Enrollments extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aSortColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aSortColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aSortColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/FeedBackTable.php
+++ b/application/models/DbTable/FeedBackTable.php
@@ -348,8 +348,10 @@ class Application_Model_DbTable_FeedBackTable extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/FeedBackTable.php
+++ b/application/models/DbTable/FeedBackTable.php
@@ -348,8 +348,12 @@ class Application_Model_DbTable_FeedBackTable extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/HomeSection.php
+++ b/application/models/DbTable/HomeSection.php
@@ -101,8 +101,10 @@ class Application_Model_DbTable_HomeSection extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/HomeSection.php
+++ b/application/models/DbTable/HomeSection.php
@@ -101,8 +101,12 @@ class Application_Model_DbTable_HomeSection extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/ParticipantMessages.php
+++ b/application/models/DbTable/ParticipantMessages.php
@@ -80,8 +80,10 @@ class Application_Model_DbTable_ParticipantMessages extends Zend_Db_Table_Abstra
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/ParticipantMessages.php
+++ b/application/models/DbTable/ParticipantMessages.php
@@ -80,8 +80,12 @@ class Application_Model_DbTable_ParticipantMessages extends Zend_Db_Table_Abstra
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Participants.php
+++ b/application/models/DbTable/Participants.php
@@ -141,8 +141,10 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -731,8 +733,10 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -849,8 +853,10 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -1118,8 +1124,10 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -1274,8 +1282,10 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -1396,8 +1406,10 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -2355,8 +2367,10 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }

--- a/application/models/DbTable/Participants.php
+++ b/application/models/DbTable/Participants.php
@@ -141,8 +141,12 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -731,8 +735,12 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -849,8 +857,12 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -1118,8 +1130,12 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -1274,8 +1290,12 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -1396,8 +1416,12 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }
@@ -2552,8 +2576,12 @@ class Application_Model_DbTable_Participants extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sortDir = strtolower($parameters['sSortDir_' . $i]) === 'desc' ? 'desc' : 'asc';
-                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[intval($parameters['iSortCol_' . $i])]) . ' ' . $sortDir);
+                    $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                 }
             }
         }

--- a/application/models/DbTable/Partners.php
+++ b/application/models/DbTable/Partners.php
@@ -55,8 +55,10 @@ class Application_Model_DbTable_Partners extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Partners.php
+++ b/application/models/DbTable/Partners.php
@@ -55,8 +55,12 @@ class Application_Model_DbTable_Partners extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/RCovid19GeneTypes.php
+++ b/application/models/DbTable/RCovid19GeneTypes.php
@@ -109,8 +109,10 @@ class Application_Model_DbTable_RCovid19GeneTypes extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/RCovid19GeneTypes.php
+++ b/application/models/DbTable/RCovid19GeneTypes.php
@@ -109,8 +109,12 @@ class Application_Model_DbTable_RCovid19GeneTypes extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/ResponseNotTestedReasons.php
+++ b/application/models/DbTable/ResponseNotTestedReasons.php
@@ -28,8 +28,10 @@ class Application_Model_DbTable_ResponseNotTestedReasons extends Zend_Db_Table_A
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/ResponseNotTestedReasons.php
+++ b/application/models/DbTable/ResponseNotTestedReasons.php
@@ -28,8 +28,12 @@ class Application_Model_DbTable_ResponseNotTestedReasons extends Zend_Db_Table_A
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/SchemeList.php
+++ b/application/models/DbTable/SchemeList.php
@@ -70,8 +70,10 @@ class Application_Model_DbTable_SchemeList extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -286,8 +288,10 @@ class Application_Model_DbTable_SchemeList extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/SchemeList.php
+++ b/application/models/DbTable/SchemeList.php
@@ -70,8 +70,12 @@ class Application_Model_DbTable_SchemeList extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -367,8 +371,12 @@ class Application_Model_DbTable_SchemeList extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Shipments.php
+++ b/application/models/DbTable/Shipments.php
@@ -144,7 +144,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -266,7 +268,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder[] = $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder[] = $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
                 }
             }
         }
@@ -445,7 +449,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder[] = $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder[] = $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
                 }
             }
         }
@@ -613,7 +619,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -826,7 +834,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -958,7 +968,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -1136,7 +1148,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -1273,7 +1287,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -1411,8 +1427,10 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-						' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+						' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1529,8 +1547,10 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1659,7 +1679,9 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder[] = $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder[] = $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
                 }
             }
         }

--- a/application/models/DbTable/Shipments.php
+++ b/application/models/DbTable/Shipments.php
@@ -144,7 +144,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -266,7 +270,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder[] = $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
                 }
             }
         }
@@ -450,7 +458,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder[] = $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
                 }
             }
         }
@@ -623,7 +635,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -837,7 +853,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -970,7 +990,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -1149,7 +1173,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -1286,7 +1314,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]) . ',';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ',';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -1);
@@ -1424,8 +1456,12 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-						' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+						' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1542,8 +1578,12 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1681,7 +1721,11 @@ class Application_Model_DbTable_Shipments extends Zend_Db_Table_Abstract
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder[] = $orderColumns[intval($parameters['iSortCol_' . $i])] . ' ' . ($parameters['sSortDir_' . $i]);
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder[] = $orderColumns[$colIdx] . ' ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]);
                 }
             }
         }

--- a/application/models/DbTable/SystemAdmin.php
+++ b/application/models/DbTable/SystemAdmin.php
@@ -28,8 +28,10 @@ class Application_Model_DbTable_SystemAdmin extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/SystemAdmin.php
+++ b/application/models/DbTable/SystemAdmin.php
@@ -28,8 +28,12 @@ class Application_Model_DbTable_SystemAdmin extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/TempMail.php
+++ b/application/models/DbTable/TempMail.php
@@ -278,8 +278,10 @@ class Application_Model_DbTable_TempMail extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/TempMail.php
+++ b/application/models/DbTable/TempMail.php
@@ -278,8 +278,12 @@ class Application_Model_DbTable_TempMail extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/TestTypenameCovid19.php
+++ b/application/models/DbTable/TestTypenameCovid19.php
@@ -129,8 +129,10 @@ class Application_Model_DbTable_TestTypenameCovid19 extends Zend_Db_Table_Abstra
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/TestTypenameCovid19.php
+++ b/application/models/DbTable/TestTypenameCovid19.php
@@ -129,8 +129,12 @@ class Application_Model_DbTable_TestTypenameCovid19 extends Zend_Db_Table_Abstra
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Testkitnames.php
+++ b/application/models/DbTable/Testkitnames.php
@@ -151,8 +151,10 @@ class Application_Model_DbTable_Testkitnames extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/Testkitnames.php
+++ b/application/models/DbTable/Testkitnames.php
@@ -159,8 +159,12 @@ class Application_Model_DbTable_Testkitnames extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/UserLoginHistory.php
+++ b/application/models/DbTable/UserLoginHistory.php
@@ -176,8 +176,10 @@ class Application_Model_DbTable_UserLoginHistory extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-                     ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+                     ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -2);

--- a/application/models/DbTable/UserLoginHistory.php
+++ b/application/models/DbTable/UserLoginHistory.php
@@ -176,8 +176,12 @@ class Application_Model_DbTable_UserLoginHistory extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-                     ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+                     ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -2);

--- a/application/models/DbTable/VlAssay.php
+++ b/application/models/DbTable/VlAssay.php
@@ -41,8 +41,10 @@ class Application_Model_DbTable_VlAssay extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/models/DbTable/VlAssay.php
+++ b/application/models/DbTable/VlAssay.php
@@ -41,8 +41,12 @@ class Application_Model_DbTable_VlAssay extends Zend_Db_Table_Abstract
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/services/ApiServices.php
+++ b/application/services/ApiServices.php
@@ -490,8 +490,10 @@ class Application_Service_ApiServices
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/services/ApiServices.php
+++ b/application/services/ApiServices.php
@@ -490,8 +490,12 @@ class Application_Service_ApiServices
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-				 	' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+				 	' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/services/Evaluation.php
+++ b/application/services/Evaluation.php
@@ -34,8 +34,10 @@ class Application_Service_Evaluation
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1500,7 +1502,7 @@ class Application_Service_Evaluation
                 if (!isset($orderColumns[$colIdx]) || $orderColumns[$colIdx] === null) {
                     continue;
                 }
-                $dir = (strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc') ? 'DESC' : 'ASC';
+                $dir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                 $expr = ($orderColumns[$colIdx] instanceof Zend_Db_Expr) ? (string) $orderColumns[$colIdx] : $orderColumns[$colIdx];
                 $sortClauses[] = new Zend_Db_Expr($expr . ' ' . $dir);
             }
@@ -1742,7 +1744,7 @@ class Application_Service_Evaluation
                 if (!isset($orderColumns[$colIdx]) || $orderColumns[$colIdx] === null) {
                     continue;
                 }
-                $dir = (strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc') ? 'DESC' : 'ASC';
+                $dir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                 $expr = ($orderColumns[$colIdx] instanceof Zend_Db_Expr) ? (string) $orderColumns[$colIdx] : $orderColumns[$colIdx];
                 $sortClauses[] = new Zend_Db_Expr($expr . ' ' . $dir);
             }
@@ -1954,7 +1956,7 @@ class Application_Service_Evaluation
                 if (!isset($orderColumns[$colIdx]) || $orderColumns[$colIdx] === null) {
                     continue;
                 }
-                $dir = (strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc') ? 'DESC' : 'ASC';
+                $dir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                 $expr = ($orderColumns[$colIdx] instanceof Zend_Db_Expr) ? (string) $orderColumns[$colIdx] : $orderColumns[$colIdx];
                 $sortClauses[] = new Zend_Db_Expr($expr . ' ' . $dir);
             }
@@ -4088,7 +4090,7 @@ class Application_Service_Evaluation
                 $colIdx = intval($parameters['iSortCol_' . $i] ?? 0);
                 if (isset($parameters['bSortable_' . $colIdx]) && $parameters['bSortable_' . $colIdx] == 'true') {
                     if (isset($aColumns[$colIdx])) {
-                        $sortDir = strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc' ? 'desc' : 'asc';
+                        $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                         $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                     }
                 }

--- a/application/services/Evaluation.php
+++ b/application/services/Evaluation.php
@@ -225,8 +225,12 @@ class Application_Service_Evaluation
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1806,7 +1810,7 @@ class Application_Service_Evaluation
                 if (!isset($orderColumns[$colIdx]) || $orderColumns[$colIdx] === null) {
                     continue;
                 }
-                $dir = (strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc') ? 'DESC' : 'ASC';
+                $dir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                 $expr = ($orderColumns[$colIdx] instanceof Zend_Db_Expr) ? (string) $orderColumns[$colIdx] : $orderColumns[$colIdx];
                 $sortClauses[] = new Zend_Db_Expr($expr . ' ' . $dir);
             }
@@ -2050,7 +2054,7 @@ class Application_Service_Evaluation
                 if (!isset($orderColumns[$colIdx]) || $orderColumns[$colIdx] === null) {
                     continue;
                 }
-                $dir = (strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc') ? 'DESC' : 'ASC';
+                $dir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                 $expr = ($orderColumns[$colIdx] instanceof Zend_Db_Expr) ? (string) $orderColumns[$colIdx] : $orderColumns[$colIdx];
                 $sortClauses[] = new Zend_Db_Expr($expr . ' ' . $dir);
             }
@@ -2264,7 +2268,7 @@ class Application_Service_Evaluation
                 if (!isset($orderColumns[$colIdx]) || $orderColumns[$colIdx] === null) {
                     continue;
                 }
-                $dir = (strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc') ? 'DESC' : 'ASC';
+                $dir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                 $expr = ($orderColumns[$colIdx] instanceof Zend_Db_Expr) ? (string) $orderColumns[$colIdx] : $orderColumns[$colIdx];
                 $sortClauses[] = new Zend_Db_Expr($expr . ' ' . $dir);
             }
@@ -4431,7 +4435,7 @@ class Application_Service_Evaluation
                 $colIdx = intval($parameters['iSortCol_' . $i] ?? 0);
                 if (isset($parameters['bSortable_' . $colIdx]) && $parameters['bSortable_' . $colIdx] == 'true') {
                     if (isset($aColumns[$colIdx])) {
-                        $sortDir = strtolower($parameters['sSortDir_' . $i] ?? 'asc') === 'desc' ? 'desc' : 'asc';
+                        $sortDir = Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i] ?? 'asc');
                         $sOrder[] = new Zend_Db_Expr(((string) $aColumns[$colIdx]) . ' ' . $sortDir);
                     }
                 }

--- a/application/services/Reports.php
+++ b/application/services/Reports.php
@@ -43,8 +43,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -649,8 +651,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -868,8 +872,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1116,8 +1122,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1388,8 +1396,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1664,8 +1674,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -2287,8 +2299,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -2487,8 +2501,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -2992,8 +3008,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) { continue; }
+                    $sOrder .= $aColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -3257,8 +3275,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -3983,8 +4003,10 @@ class Application_Service_Reports
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' '
-                        . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) { continue; }
+                    $sOrder .= $orderColumns[$colIdx] . ' '
+                        . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -2);
@@ -4334,8 +4356,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $searchColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($searchColumns[$colIdx])) { continue; }
+                    $sOrder .= $searchColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -4535,8 +4559,10 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $searchColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($searchColumns[$colIdx])) { continue; }
+                    $sOrder .= $searchColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/services/Reports.php
+++ b/application/services/Reports.php
@@ -43,8 +43,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -667,8 +671,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -886,8 +894,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1134,8 +1146,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1406,8 +1422,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -1682,8 +1702,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -2305,8 +2329,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -2505,8 +2533,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -3010,8 +3042,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $aColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($aColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $aColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -3275,8 +3311,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -4064,8 +4104,12 @@ class Application_Service_Reports
         if (isset($parameters['iSortCol_0'])) {
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . ' '
-                        . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($orderColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $orderColumns[$colIdx] . ' '
+                        . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
             $sOrder = substr_replace($sOrder, '', -2);
@@ -4415,8 +4459,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $searchColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($searchColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $searchColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 
@@ -4616,8 +4664,12 @@ class Application_Service_Reports
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
                 if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                    $sOrder .= $searchColumns[intval($parameters['iSortCol_' . $i])] . '
-					    ' . ($parameters['sSortDir_' . $i]) . ', ';
+                    $colIdx = intval($parameters['iSortCol_' . $i]);
+                    if (!isset($searchColumns[$colIdx])) {
+                        continue;
+                    }
+                    $sOrder .= $searchColumns[$colIdx] . '
+					    ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                 }
             }
 

--- a/application/services/Shipments.php
+++ b/application/services/Shipments.php
@@ -137,10 +137,12 @@ class Application_Service_Shipments
         if (isset($parameters['iSortCol_0'])) {
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
-                if (isset($orderColumns[intval($parameters['iSortCol_' . $i])]) && !empty($orderColumns[intval($parameters['iSortCol_' . $i])])) {
+                $colIdx = intval($parameters['iSortCol_' . $i]);
+                if (!isset($orderColumns[$colIdx])) { continue; }
+                if (!empty($orderColumns[$colIdx])) {
                     if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                        $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-                            ' . ($parameters['sSortDir_' . $i]) . ', ';
+                        $sOrder .= $orderColumns[$colIdx] . '
+                            ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                     }
                 }
             }
@@ -3919,10 +3921,12 @@ class Application_Service_Shipments
         if (isset($parameters['iSortCol_0'])) {
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
-                if (isset($orderColumns[intval($parameters['iSortCol_' . $i])]) && !empty($orderColumns[intval($parameters['iSortCol_' . $i])])) {
+                $colIdx = intval($parameters['iSortCol_' . $i]);
+                if (!isset($orderColumns[$colIdx])) { continue; }
+                if (!empty($orderColumns[$colIdx])) {
                     if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                        $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-                            ' . ($parameters['sSortDir_' . $i]) . ', ';
+                        $sOrder .= $orderColumns[$colIdx] . '
+                            ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                     }
                 }
             }

--- a/application/services/Shipments.php
+++ b/application/services/Shipments.php
@@ -137,10 +137,14 @@ class Application_Service_Shipments
         if (isset($parameters['iSortCol_0'])) {
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
-                if (isset($orderColumns[intval($parameters['iSortCol_' . $i])]) && !empty($orderColumns[intval($parameters['iSortCol_' . $i])])) {
+                $colIdx = intval($parameters['iSortCol_' . $i]);
+                if (!isset($orderColumns[$colIdx])) {
+                    continue;
+                }
+                if (!empty($orderColumns[$colIdx])) {
                     if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                        $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-                            ' . ($parameters['sSortDir_' . $i]) . ', ';
+                        $sOrder .= $orderColumns[$colIdx] . '
+                            ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                     }
                 }
             }
@@ -4076,10 +4080,14 @@ class Application_Service_Shipments
         if (isset($parameters['iSortCol_0'])) {
             $sOrder = '';
             for ($i = 0; $i < intval($parameters['iSortingCols']); $i++) {
-                if (isset($orderColumns[intval($parameters['iSortCol_' . $i])]) && !empty($orderColumns[intval($parameters['iSortCol_' . $i])])) {
+                $colIdx = intval($parameters['iSortCol_' . $i]);
+                if (!isset($orderColumns[$colIdx])) {
+                    continue;
+                }
+                if (!empty($orderColumns[$colIdx])) {
                     if ($parameters['bSortable_' . intval($parameters['iSortCol_' . $i])] == 'true') {
-                        $sOrder .= $orderColumns[intval($parameters['iSortCol_' . $i])] . '
-                            ' . ($parameters['sSortDir_' . $i]) . ', ';
+                        $sOrder .= $orderColumns[$colIdx] . '
+                            ' . Pt_Commons_General::sanitizeSortDirection($parameters['sSortDir_' . $i]) . ', ';
                     }
                 }
             }

--- a/library/Pt/Commons/General.php
+++ b/library/Pt/Commons/General.php
@@ -202,6 +202,11 @@ class Pt_Commons_General
         return $files;
     }
 
+    public static function sanitizeSortDirection($raw): string
+    {
+        return strtoupper((string) $raw) === 'DESC' ? 'DESC' : 'ASC';
+    }
+
     // Generate a ULID
     public static function generateULID($attachExtraString = true): string
     {


### PR DESCRIPTION
## Summary

Fixes SQL injection via the DataTables `sSortDir_$i` parameter, which was previously concatenated unsanitized into `ORDER BY` clauses across the codebase. Also closes an out-of-range array-index path via `iSortCol_$i`.

**Part 2 (sSearch LIKE-clause parameterization) is tracked separately.**

---

## Changes

### New helper — `library/Pt/Commons/General.php`

Added `Pt_Commons_General::sanitizeSortDirection(string $raw): string` — whitelists `ASC`/`DESC` and defaults to `ASC` for any other input.

### 26 application files patched (61 call-sites)

Every site that previously concatenated `$parameters['sSortDir_' . $i]` directly into an ORDER BY string now routes through the whitelist helper. Sites that already had an inline ternary (`strtolower(...) === 'desc' ? ...`) were also converted to use the shared helper for consistency.

A `$colIdx` bounds-check (`if (!isset($columns[$colIdx])) { continue; }`) was added at every sort block so that an out-of-range `iSortCol_` value cannot silently inject an empty column name into the query.

**Services:**
- `application/services/Reports.php` — 13 sites
- `application/services/Evaluation.php` — 5 sites
- `application/services/Shipments.php` — 2 sites
- `application/services/ApiServices.php` — 1 site

**Models:**
- `application/models/DbTable/Shipments.php` — 11 sites
- `application/models/DbTable/Participants.php` — 7 sites
- `application/models/DbTable/SchemeList.php` — 2 sites
- `application/models/DbTable/Distribution.php` — 2 sites
- `application/models/DbTable/CertificateBatches.php`
- `application/models/DbTable/ContactUs.php`
- `application/models/DbTable/DataManagers.php`
- `application/models/DbTable/EidDetectionAssay.php`
- `application/models/DbTable/EidExtractionAssay.php`
- `application/models/DbTable/Enrollments.php`
- `application/models/DbTable/FeedBackTable.php`
- `application/models/DbTable/HomeSection.php`
- `application/models/DbTable/ParticipantMessages.php`
- `application/models/DbTable/Partners.php`
- `application/models/DbTable/RCovid19GeneTypes.php`
- `application/models/DbTable/ResponseNotTestedReasons.php`
- `application/models/DbTable/SystemAdmin.php`
- `application/models/DbTable/TempMail.php`
- `application/models/DbTable/TestTypenameCovid19.php`
- `application/models/DbTable/Testkitnames.php`
- `application/models/DbTable/UserLoginHistory.php`
- `application/models/DbTable/VlAssay.php`

---

## Verification

- `php -l` passes on all 27 modified files.
- Zero remaining raw `$parameters['sSortDir_']` concatenations in `application/`.
- 61 call-sites confirmed through `sanitizeSortDirection`.

---

## Out of scope

`sSearch` / `sSearch_$i` LIKE-clause injection is **not** addressed here — that is part 2.

---
_Generated by [Claude Code](https://claude.ai/code/session_015ScADFVSWDtZNfuThBetTS)_