### PR TITLE
Add backup/recovery/migration docs; align Docker with PHP 8.4 floor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-apache
+FROM php:8.4-apache
 
 # System dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "mpdf/mpdf": "^8.3",
         "mpdf/psr-http-message-shim": "^1.0",
         "myclabs/php-enum": "^1.8",
-        "nesbot/carbon": "^3.11",
+        "nesbot/carbon": "^3.13",
         "phpmyadmin/sql-parser": "^6.0",
         "phpoffice/phpspreadsheet": "^5.9",
         "phpoffice/phpword": "^1.4",
@@ -33,7 +33,7 @@
         "setasign/fpdi": "^2.6",
         "shardj/zf1-future": "^1.25",
         "symfony/console": "^8.1",
-        "symfony/mailer": "^8.0",
+        "symfony/mailer": "^8.1",
         "symfony/uid": "^8.1",
         "tecnickcom/tcpdf": "^6.11"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "214961b661a7366e7287fcf175fc2c22",
+    "content-hash": "f8ebf40400585a1787fcc9d0fe452eb5",
     "packages": [
         {
             "name": "amitdugar/archiveutil",
@@ -5871,16 +5871,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.13",
+            "version": "v3.95.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "ea941114a002eb5e5876f190223deec1066c482c"
+                "reference": "3e47e5d50046f87e3244acde2fe655d1a3b72555"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/ea941114a002eb5e5876f190223deec1066c482c",
-                "reference": "ea941114a002eb5e5876f190223deec1066c482c",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/3e47e5d50046f87e3244acde2fe655d1a3b72555",
+                "reference": "3e47e5d50046f87e3244acde2fe655d1a3b72555",
                 "shasum": ""
             },
             "require": {
@@ -5920,7 +5920,7 @@
                 "php-coveralls/php-coveralls": "^2.9.1",
                 "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.8",
                 "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.8",
-                "phpunit/phpunit": "^9.6.35 || ^10.5.64 || ^11.5.56",
+                "phpunit/phpunit": "^9.6.35 || ^10.5.64 || ^11.5.56 || ^12.5.31",
                 "symfony/polyfill-php85": "^1.38",
                 "symfony/var-dumper": "^5.4.48 || ^6.4.36 || ^7.4.8 || ^8.1.0",
                 "symfony/yaml": "^5.4.53 || ^6.4.41 || ^7.4.13 || ^8.1.0"
@@ -5964,7 +5964,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.13"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.15"
             },
             "funding": [
                 {
@@ -5972,7 +5972,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-07-10T09:23:21+00:00"
+            "time": "2026-07-15T09:51:47+00:00"
         },
         {
             "name": "league/iso3166",

--- a/docs/backup-and-migration.md
+++ b/docs/backup-and-migration.md
@@ -1,0 +1,188 @@
+# Backup, Recovery & Migration
+
+This page covers three related operations for an ePT instance: taking **backups**, **restoring** them (disaster recovery), and **moving an instance to a new machine**.
+
+ePT is designed to run as a **single central instance**, so the tooling here favours simple, operator-driven procedures over fleet automation. The building blocks are:
+
+| Tool | Role |
+| --- | --- |
+| `vendor/bin/db-tools` (`amitdugar/db-tools`) | Create, restore, verify, and point-in-time-recover database backups |
+| `composer` scripts | Convenience wrappers around db-tools + config snapshot |
+| `bin/setup.sh` | Fresh install on a new machine, with an optional database import |
+| `bin/upgrade.sh` (`ept-update`) | Takes pre-upgrade safety backups automatically |
+
+!!! info "What is and isn't automated"
+    db-tools handles the **database** end-to-end. Application **code** is always fetched fresh from GitHub by `setup.sh`. **Uploaded files** (`public/uploads/`) and **config secrets** are never carried automatically — you copy those by hand during a move (see [Migrating to a new machine](#migrating-to-a-new-machine)).
+
+---
+
+## Backups
+
+### Quick backup
+
+From the ePT directory:
+
+```bash
+# Database only
+composer db-backup
+
+# Database + a snapshot of application.ini (config)
+composer backup
+```
+
+Both wrap `vendor/bin/db-tools`. Archives are written to `<ept>/backups` with a 15-archive retention by default.
+
+!!! warning "Backups are encrypted by default"
+    `db-tools backup` encrypts archives (`.gpg`) using an encryption password unless you pass `--no-encrypt`. **You need the same password to restore.** For a backup you intend to restore on a *different* machine, either record the encryption password or create an unencrypted archive with `--no-encrypt` (see [Migrating](#migrating-to-a-new-machine)).
+
+### Direct db-tools usage
+
+```bash
+# Encrypted, compressed archive into the default backups dir
+php vendor/bin/db-tools backup
+
+# Choose compression backend and a filename label
+php vendor/bin/db-tools backup --compression=zstd --label=nightly
+
+# Unencrypted archive (e.g. for a same-day migration)
+php vendor/bin/db-tools backup --no-encrypt
+
+# List existing archives / check integrity
+php vendor/bin/db-tools show
+php vendor/bin/db-tools verify
+```
+
+The active profile (host, database, output dir, retention, encryption) is shown with:
+
+```bash
+php vendor/bin/db-tools config:show
+```
+
+### Scheduling
+
+Run `composer db-backup` (or `php vendor/bin/db-tools backup`) from cron on whatever cadence the site needs. Old archives beyond the retention count are pruned automatically.
+
+!!! note "Pre-upgrade backups are automatic"
+    `ept-update` (`bin/upgrade.sh`) offers to back up the **database** to `/var/ept-backup/db/` and the **ePT folder** to `/var/ept-backup/www/` before every update. Those pre-upgrade dumps are a valid source for a restore or a migration — you don't have to take a fresh one just to move.
+
+---
+
+## Restore & disaster recovery
+
+To restore onto the **same machine** (or to rebuild after data loss):
+
+```bash
+# Interactive: pick an archive from the backups dir
+php vendor/bin/db-tools restore
+
+# Restore a specific archive
+php vendor/bin/db-tools restore /path/to/ept-YYYYMMDD-HHMMSS.sql.zst.gpg
+
+# Encrypted archive — supply the password
+php vendor/bin/db-tools restore <archive> --encryption-password='...'
+```
+
+db-tools takes a **safety backup before restoring** by default (skip with `--skip-safety-backup`), and prompts for confirmation unless you pass `--force`.
+
+### Point-in-time recovery
+
+If binary logging is enabled, db-tools can roll forward past the last full backup:
+
+```bash
+php vendor/bin/db-tools pitr-info                 # inspect available binlogs
+php vendor/bin/db-tools pitr-restore              # apply binlogs to a target time
+php vendor/bin/db-tools purge-binlogs             # housekeeping
+```
+
+---
+
+## Migrating to a new machine
+
+`setup.sh` installs fresh code and **imports your database**, but it does **not** carry over uploads or config from the old machine. A complete move is therefore three parts: database, uploaded files, and config secrets.
+
+!!! danger "Preserve the salt and form secret"
+    Two values must survive the move, or existing hashed/encrypted data and logged-in sessions will break:
+
+    - `application/configs/application.ini` → `security.salt`
+    - `application/configs/.env` → `FORM_SECRET`
+
+    A fresh `setup.sh` **regenerates both**. Copy the originals from the old machine *after* setup completes.
+
+### 1. On the old machine
+
+```bash
+# Database — unencrypted for a straightforward migration
+php vendor/bin/db-tools backup --no-encrypt
+# (or keep it encrypted and carry the --encryption-password to the new box)
+
+# Uploaded files and config secrets — copy these off the box
+#   application/configs/application.ini   (contains security.salt + DB creds)
+#   application/configs/config.ini        (org / evaluation settings)
+#   application/configs/.env              (FORM_SECRET)
+#   public/uploads/                       (participant uploads, assets)
+```
+
+Transfer the archive plus those files/folders to the new server (scp/rsync/USB — your choice).
+
+### 2. On the new machine
+
+Run setup, pointing `--db` at the transferred archive (local path **or** URL; `.sql`, `.gz`, `.zip` supported):
+
+```bash
+cd ~
+sudo wget -O ept-setup.sh https://raw.githubusercontent.com/deforay/ept/master/bin/setup.sh
+sudo chmod +x ept-setup.sh
+sudo ./ept-setup.sh --db /path/to/ept-backup.sql.gz
+```
+
+This builds the LAMP stack, downloads ePT, and imports your database instead of the bundled `sql/init.sql`.
+
+### 3. Restore uploads and config, then verify
+
+```bash
+# Put the uploaded files back
+rsync -a /path/to/old/public/uploads/  /var/www/ept/public/uploads/
+
+# Restore config secrets (review DB host/creds for the new box first)
+cp /path/to/old/application.ini  /var/www/ept/application/configs/application.ini
+cp /path/to/old/config.ini       /var/www/ept/application/configs/config.ini
+cp /path/to/old/.env             /var/www/ept/application/configs/.env
+
+# Fix ownership/permissions if needed, then run any pending migrations
+cd /var/www/ept && composer post-update
+```
+
+!!! tip "Check DB credentials after copying application.ini"
+    `application.ini` carries the **old** machine's database host/user/password. If the new machine's MySQL differs, update `resources.db.params.*` before loading the app.
+
+Finally, log in at `http://<host>/admin`, confirm participants/shipments/reports render, and generate one report end-to-end to be sure uploads and the salt/secret came across intact.
+
+---
+
+## What setup.sh carries vs. what you carry
+
+| Item | Carried by `setup.sh` | You handle |
+| --- | --- | --- |
+| Application code | ✅ fresh from GitHub master | — |
+| Database | ✅ via `--db=<archive>` | Produce the archive with db-tools |
+| `public/uploads/` | ❌ | Copy manually |
+| `application.ini` / `config.ini` / `.env` | ❌ regenerated from templates | Copy manually |
+| `security.salt` / `FORM_SECRET` | ❌ regenerated | **Must** copy from old machine |
+
+---
+
+## Command reference
+
+```bash
+composer backup                    # db-tools backup + config snapshot
+composer db-backup                 # database backup only
+php vendor/bin/db-tools backup     # backup (encrypted, compressed) → <ept>/backups
+php vendor/bin/db-tools restore    # restore (interactive; safety backup first)
+php vendor/bin/db-tools show       # list archives
+php vendor/bin/db-tools verify     # integrity check
+php vendor/bin/db-tools export     # plain SQL export
+php vendor/bin/db-tools import     # plain SQL import
+php vendor/bin/db-tools config:show   # active profile
+sudo ./ept-setup.sh --db <archive>    # fresh install + DB import (new machine)
+sudo ept-update                       # update in place (auto pre-upgrade backup)
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -118,7 +118,7 @@ Available environment variables:
 
 The Docker setup runs everything in two containers:
 
-- **ept** — PHP 8.2, Apache, Node.js (for chart rendering), Composer dependencies, and a cron job for the task scheduler
+- **ept** — PHP 8.4, Apache, Node.js (for chart rendering), Composer dependencies, and a cron job for the task scheduler
 - **ept-db** — MySQL 8.0, seeded from `sql/init.sql`
 
 On first startup, the entrypoint script automatically:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Home: README.md
   - Setup & Operations:
       - Setup: setup.md
+      - Backup, Recovery & Migration: backup-and-migration.md
       - Infrastructure Planning: infrastructure.md
       - CLI Tools: cli-tools.md
   - Guides:


### PR DESCRIPTION
- New docs/backup-and-migration.md (db-tools backup/restore/PITR + machine move), added to nav
- Dockerfile php:8.2 -> php:8.4 to match composer require php ^8.4 (symfony 8 / carbon 3)
- setup.md Docker note 8.2 -> 8.4
- Bump nesbot/carbon ^3.13, symfony/mailer ^8.1 (match installed/locked)
