### PR TITLE
chore(deps): update amitdugar/db-tools to 3.2.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "amitdugar/db-tools",
-            "version": "3.1.0",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amitdugar/db-tools.git",
-                "reference": "f80eb51b9f57c91f31b7eb3e902f1d7e24f1432f"
+                "reference": "a785cd77c8429fc3ae206b42ec9402b7f65ba25d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amitdugar/db-tools/zipball/f80eb51b9f57c91f31b7eb3e902f1d7e24f1432f",
-                "reference": "f80eb51b9f57c91f31b7eb3e902f1d7e24f1432f",
+                "url": "https://api.github.com/repos/amitdugar/db-tools/zipball/a785cd77c8429fc3ae206b42ec9402b7f65ba25d",
+                "reference": "a785cd77c8429fc3ae206b42ec9402b7f65ba25d",
                 "shasum": ""
             },
             "require": {
@@ -82,6 +82,7 @@
                 "symfony/process": "^8.1"
             },
             "require-dev": {
+                "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^13.1"
             },
             "bin": [
@@ -116,7 +117,7 @@
                 "issues": "https://github.com/amitdugar/db-tools/issues",
                 "source": "https://github.com/amitdugar/db-tools"
             },
-            "time": "2026-06-15T11:03:21+00:00"
+            "time": "2026-08-04T10:46:50+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",


### PR DESCRIPTION
Brings in two data-integrity fixes that were failing silently, so neither would
have been reported from here.

3.2.0 fixed silent backup corruption: the dump pipeline ran as a shell string,
so the exit status reflected only the last stage. A mysqldump that died partway
was invisible, because the compressor downstream succeeded on the truncated
input and exited 0. The backup was reported successful and a valid-looking but
incomplete archive was written. It now runs under pipefail. Any archive in
backups/ written before this is not proven complete.

3.2.2 fixed a data-loss bug in restore: recreateDatabase() issued
DROP DATABASE / CREATE DATABASE before validating that the archive existed, so
a mistyped path destroyed the target database and only then reported "Archive
not found". Validation now precedes anything destructive. This project does not
pass --skip-safety-backup anywhere, so the automatic pre-restore archive would
have covered it, but the ordering is now correct regardless.

3.2.1 fixed --version, which had reported a stale 3.0.2 since that release.
It now resolves from Composer and reports the real version, so it can be
trusted to confirm what is deployed on a server.

Also adds MariaDB support: flavour detection from VERSION(), resolution of the
renamed mariadb-dump style client binaries, and a collation fix so
utf8mb4_0900_ai_ci is no longer chosen on MariaDB 10.x, where every ALTER
aborted with "Unknown collation".

Inside ^3.1, so composer.json is unchanged. No BC breaks.
